### PR TITLE
PR: Blockchain Day 4: Task 1: Implement Ether Transfer and Rejection Handling Contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# Basic-Training
+# Solidity Ether Transfer & Rejection Handling
+
+This project contains a set of Solidity smart contracts (`Task_1.sol`) that demonstrate fundamental patterns for sending, forwarding, and handling Ether transfers between contracts. It showcases a successful transfer chain and a scenario where a transfer is intentionally and gracefully rejected.
+
+This is an excellent example for understanding the modern, recommended way to handle Ether payments using the low-level `.call()` method.
+
+---
+
+## Contracts Overview
+
+There are four contracts, each with a specific role:
+
+* **`ContractA_Caller`**: The entry point for all interactions. It initiates Ether transfers to other contracts.
+* **`ContractB_Forwarder`**: A middleman contract. It is designed to automatically receive Ether and forward it to another address (`ContractC_Receiver`).
+* **`ContractC_Receiver`**: The final destination for a successful transfer. It simply has the functionality to receive Ether.
+* **`ContractD_Rejector`**: A contract specifically designed to fail. It will always reject any Ether sent to it.
+
+---
+
+## Scenarios Demonstrated
+
+### 1. Successful Forwarding Chain (A → B → C)
+
+This scenario shows a successful multi-hop Ether transfer.
+
+1.  A user calls the `sendToB(addressB)` function in `ContractA_Caller`, sending some Ether with the transaction.
+2.  `ContractA_Caller` uses `addressB.call{value: msg.value}("")` to send the Ether to `ContractB_Forwarder`.
+3.  The `receive()` function in `ContractB_Forwarder` is triggered. It immediately forwards the received Ether to `ContractC_Receiver`.
+4.  The `receive()` function in `ContractC_Receiver` is triggered, and the contract successfully receives the Ether, completing the chain.
+
+### 2. Gracefully Handled Rejection (A → D)
+
+This scenario demonstrates how to safely attempt an Ether transfer that might fail, without reverting the entire parent transaction.
+
+1.  A user calls the `sendToD(addressD)` function in `ContractA_Caller`, sending some Ether.
+2.  `ContractA_Caller` attempts to send the Ether to `ContractD_Rejector` using `.call()`.
+3.  The `receive()` function in `ContractD_Rejector` is triggered but immediately executes `revert("...")`, rejecting the payment.
+4.  Because `.call()` was used, the failure does not cause the transaction in `ContractA_Caller` to revert. Instead, `.call()` returns `success = false`.
+5.  The code in `sendToD` catches this `false` value and emits a `ForwardFailure` event, logging the reason for the failure. The transaction in `ContractA_Caller` completes successfully.
+
+---
+
+## Key Concepts
+
+* **`address.call{value: amount}("")`**: This is the modern, recommended low-level method for sending Ether. Unlike `.transfer()` or `.send()`, it does not have a hardcoded gas limit and it returns a boolean (`success`) indicating if the call was successful, which allows for robust error handling.
+* **`receive()` external payable**: This is a special function in Solidity. A contract can have at most one `receive` function, which is executed on a call to the contract with empty calldata. This is the function that gets triggered when the contract receives plain Ether without any function being called.
+* **Error Handling with `.call()`**: This example clearly contrasts two ways to handle the result of `.call()`:
+    * Using `require(success, "Error message")` when a successful transfer is critical for the function to continue.
+    * Using an `if/else` block to gracefully handle an expected failure without reverting the entire transaction.

--- a/Task_1.sol
+++ b/Task_1.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title ContractA_Caller
+ * @notice This contract initiates Ether transfers to other contracts.
+ * @dev It has two functions: one for a successful transfer chain (A->B->C)
+ * and one for a transfer that is expected to be rejected (A->D).
+ */
+contract ContractA_Caller {
+    event ForwardSuccess(address indexed to, uint256 amount);
+    event ForwardFailure(address indexed to, bytes reason);
+
+    /**
+     * @notice Sends ETH to ContractB, which should forward it to ContractC.
+     * @param contractB The address of the forwarding contract (ContractB).
+     * @dev This function sends the full value of the transaction to contractB.
+     * It uses the .call method, which is the recommended way to send Ether.
+     */
+    function sendToB(address payable contractB) external payable {
+        require(msg.value > 0, "Must send some Ether");
+        (bool success, ) = contractB.call{value: msg.value}("");
+        require(success, "Failed to send Ether to ContractB");
+    }
+
+    /**
+     * @notice Attempts to send ETH to ContractD, which is designed to reject it.
+     * @param contractD The address of the rejecting contract (ContractD).
+     * @dev The transaction is expected to revert because ContractD will reject the payment.
+     * We use a try-catch block to handle the expected failure gracefully.
+     */
+    function sendToD(address payable contractD) external payable {
+        require(msg.value > 0, "Must send some Ether");
+
+        // Using .call to attempt the transfer
+        (bool success, bytes memory reason) = contractD.call{value: msg.value}("");
+
+        if (success) {
+            emit ForwardSuccess(contractD, msg.value);
+        } else {
+            // This event will be emitted, showing the failure reason from ContractD.
+            emit ForwardFailure(contractD, reason);
+        }
+    }
+}
+
+/**
+ * @title ContractB_Forwarder
+ * @notice This contract receives Ether and automatically forwards it to ContractC.
+ * @dev It uses the receive() special function to handle incoming Ether.
+ */
+contract ContractB_Forwarder {
+    address payable public contractC_address;
+
+    event Forwarded(address indexed to, uint256 amount);
+
+    /**
+     * @param initial_C_Address The address of ContractC where Ether will be forwarded.
+     */
+    constructor(address payable initial_C_Address) {
+        contractC_address = initial_C_Address;
+    }
+
+    // This function is automatically triggered when the contract receives Ether.
+    receive() external payable {
+        require(msg.value > 0, "Must receive some Ether to forward");
+        (bool success, ) = contractC_address.call{value: msg.value}("");
+        require(success, "Forwarding to ContractC failed");
+
+        emit Forwarded(contractC_address, msg.value);
+    }
+}
+
+/**
+ * @title ContractC_Receiver
+ * @notice This is the final destination for the Ether in the successful transfer chain.
+ * @dev It simply accepts Ether.
+ */
+contract ContractC_Receiver {
+    event Received(address indexed from, uint256 amount);
+
+    // This function is automatically triggered when the contract receives Ether.
+    receive() external payable {
+        emit Received(msg.sender, msg.value);
+    }
+}
+
+/**
+ * @title ContractD_Rejector
+ * @notice This contract is designed to always reject any Ether sent to it.
+ * @dev Its receive() function explicitly reverts the transaction.
+ */
+contract ContractD_Rejector {
+    // This function is automatically triggered when the contract receives Ether
+    // and it will always fail the transaction.
+    receive() external payable {
+        revert("ContractD does not accept Ether payments.");
+    }
+}


### PR DESCRIPTION
This pull request introduces a set of smart contracts (`Task_1.sol`) to demonstrate best practices for sending, receiving, and forwarding Ether between contracts in Solidity. The implementation focuses on using the low-level `.call()` method to illustrate both a successful multi-contract transfer chain and a gracefully handled payment rejection.

This serves as a foundational example for developers to understand and implement robust Ether-handling logic.

#### Changes

* **`ContractA_Caller`**: Added a contract to serve as the entry point for initiating transfers.
* **`ContractB_Forwarder`**: Added a contract that automatically forwards any received Ether using its `receive()` function.
* **`ContractC_Receiver`**: Added a simple destination contract that can receive Ether.
* **`ContractD_Rejector`**: Added a contract whose `receive()` function is designed to always `revert()`, demonstrating a payment rejection.
* **Scenarios**: The contracts work together to showcase two key flows:
    1.  A successful transfer from `A -> B -> C`.
    2.  A handled rejection from `A -> D`, where the failure is caught in `A` without reverting the parent call.

#### How to Test

1.  Deploy `ContractC_Receiver` and `ContractD_Rejector`.
2.  Deploy `ContractB_Forwarder`, passing the deployed address of `ContractC_Receiver` into its constructor.
3.  Deploy `ContractA_Caller`.
4.  **Test Success Case**: Call the `sendToB` function on the `ContractA_Caller` instance. Pass the address of `ContractB_Forwarder` as the argument and send > 0 ETH with the transaction.
    * **Expected Result**: The transaction should succeed, and the ETH balance of `ContractC_Receiver` should increase.
5.  **Test Rejection Case**: Call the `sendToD` function on the `ContractA_Caller` instance. Pass the address of `ContractD_Rejector` as the argument and send > 0 ETH with the transaction.
    * **Expected Result**: The transaction should succeed (it should *not* revert). A `ForwardFailure` event should be emitted from `ContractA_Caller` containing the revert reason from `ContractD_Rejector`.





---
Please let me know for any required changes!!