### PR TITLE
PR: Blockchain Day 4: Task 2: Implement ERC20 Token Approval and Forwarding Chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# Basic-Training
+# Solidity ERC20 Token Transfer and Approval Chains
+
+This project (`Task_2.sol`) demonstrates how to handle multi-step ERC20 token transfers between smart contracts using the `approve` and `transferFrom` pattern. It includes a full-featured example of a successful forwarding chain and a scenario where a token transfer is intentionally reverted.
+
+This is a critical concept for anyone building DeFi applications, as it's the standard way for contracts to interact with tokens they don't own.
+
+---
+
+## Contracts Overview
+
+* **`MyToken`**: A basic ERC20 token contract with a public `mint` function, allowing anyone to get tokens for testing purposes.
+* **`ContractA_TokenCaller`**: The starting point for the token transfer logic. It is responsible for pulling tokens from the end-user and then delegating the next step to another contract.
+* **`ContractB_TokenForwarder`**: The middleman in the successful transfer chain. It is designed to pull tokens from `ContractA` and send them to the final destination, `ContractC`.
+* **`ContractC_TokenReceiver`**: The final destination for the tokens in the successful transfer. It holds the tokens and has a function to check its balance.
+* **`ContractD_TokenRejector`**: A contract designed to fail. It has a function that, when called, will always revert the transaction.
+
+---
+
+## Scenarios Demonstrated
+
+The core of this project is the **approve/transferFrom** pattern. A user doesn't *send* tokens to Contract A. Instead, the user **approves** Contract A to withdraw a certain amount, and then Contract A **pulls** the tokens using `transferFrom`.
+
+### 1. Successful Forwarding Chain (User → A → B → C)
+
+This scenario shows how tokens can be moved through multiple contracts without the original owner having to trust every contract in the chain.
+
+1.  **User Pre-approval**: The user (an Externally Owned Account) first calls the `approve()` function on the `MyToken` contract, granting `ContractA_TokenCaller` permission to withdraw a specific amount of tokens.
+2.  **Start the Chain**: The user calls `startForwardingChain()` on `ContractA_TokenCaller`.
+3.  **Step A**: `ContractA` pulls the approved tokens from the user to itself using `token.transferFrom(msg.sender, address(this), amount)`.
+4.  **Step A to B**: `ContractA` then approves `ContractB_TokenForwarder` to withdraw those same tokens from it.
+5.  **Trigger B**: `ContractA` calls the `forwardTokens()` function on `ContractB`.
+6.  **Step B to C**: Inside `forwardTokens()`, `ContractB` now has the authority to pull the tokens from `ContractA` and send them directly to the final destination, `ContractC`, using `token.transferFrom(addressA, addressC, amount)`.
+
+### 2. Reverting Transfer Chain (User → A → D)
+
+This scenario shows how a failure in a downstream contract will revert the entire transaction chain.
+
+1.  **User Pre-approval**: The user approves `ContractA_TokenCaller` to withdraw tokens.
+2.  **Start the Chain**: The user calls `startRejectionChain()` on `ContractA_TokenCaller`.
+3.  **Step A**: `ContractA` pulls the tokens from the user.
+4.  **Step A to D**: `ContractA` approves `ContractD_TokenRejector` to pull the tokens.
+5.  **Trigger D**: `ContractA` calls the `tryToPullTokens()` function on `ContractD`.
+6.  **Rejection**: The function in `ContractD` immediately reverts. Because this call was not wrapped in a `try/catch` block, the entire transaction, including the initial `transferFrom` in `ContractA`, is reverted. The user's tokens are returned as if the transaction never happened.
+
+---
+
+## Key Concepts
+
+* **`approve(spender, amount)`**: An ERC20 function where a token owner gives a `spender` (another address or contract) permission to withdraw up to `amount` tokens from their account.
+* **`transferFrom(from, to, amount)`**: An ERC20 function that allows a `spender` to transfer tokens from the `from` address to the `to` address. This can only succeed if the `spender` has been previously approved for at least that `amount`.
+* **Chain of Approvals**: This project demonstrates that for a contract to move tokens through a multi-step process, a chain of approvals is necessary. `User` must approve `A`, and `A` must approve `B`.
+* **Transaction Reversion**: Unlike the Ether transfer example using `.call()`, a direct external function call that reverts will cause the entire parent transaction to revert unless handled with a `try/catch` block. This example shows the default "all-or-nothing" behavior.

--- a/Task_2.sol
+++ b/Task_2.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @title MyToken
+ * @notice A basic mintable ERC20 token for testing purposes.
+ */
+contract MyToken is ERC20 {
+    constructor() ERC20("MyToken", "MTK") {}
+
+    // Allows anyone to mint tokens to themselves for testing
+    function mint(uint256 amount) public {
+        _mint(msg.sender, amount);
+    }
+}
+
+/**
+ * @title ContractA_TokenCaller
+ * @notice Initiates the token transfer chain.
+ * @dev It pulls tokens from the user (who must first grant an allowance),
+ * then approves ContractB to perform the next step.
+ */
+contract ContractA_TokenCaller {
+    event ChainStarted(address indexed token, address indexed destinationB, uint256 amount);
+    event RejectionChainStarted(address indexed token, address indexed destinationD, uint256 amount);
+
+    // Scenario 1: Successful Forwarding (User -> A -> B -> C)
+    function startForwardingChain(
+        address tokenAddress,
+        address contractB,
+        address contractC,
+        uint256 amount
+    ) external {
+        IERC20 token = IERC20(tokenAddress);
+        
+        // 1. Pull tokens from the User (msg.sender) to this contract (A).
+        // This requires the User to have approved this contract first.
+        token.transferFrom(msg.sender, address(this), amount);
+
+        // 2. Approve ContractB to spend these tokens on behalf of this contract (A).
+        token.approve(contractB, amount);
+        
+        emit ChainStarted(tokenAddress, contractB, amount);
+        
+        // 3. Trigger the forwarding function in ContractB.
+        // We must use an interface or a direct contract type to call the function.
+        ContractB_TokenForwarder(payable(contractB)).forwardTokens(tokenAddress, contractC, amount);
+    }
+
+    // Scenario 2: Rejected Transfer (User -> A -> D)
+    function startRejectionChain(address tokenAddress, address contractD, uint256 amount) external {
+        IERC20 token = IERC20(tokenAddress);
+
+        // 1. Pull tokens from the user to this contract (A).
+        token.transferFrom(msg.sender, address(this), amount);
+
+        // 2. Approve ContractD to spend tokens.
+        token.approve(contractD, amount);
+
+        emit RejectionChainStarted(tokenAddress, contractD, amount);
+        
+        // 3. Trigger the rejection function in ContractD. This call will revert.
+        ContractD_TokenRejector(payable(contractD)).tryToPullTokens(tokenAddress, address(this), amount);
+    }
+}
+
+/**
+ * @title ContractB_TokenForwarder
+ * @notice Forwards tokens from ContractA to ContractC.
+ */
+contract ContractB_TokenForwarder {
+    event TokensForwarded(address indexed token, address indexed from, address indexed to, uint256 amount);
+
+    function forwardTokens(address tokenAddress, address contractC, uint256 amount) external {
+        IERC20 token = IERC20(tokenAddress);
+
+        // Pull tokens from ContractA (msg.sender of the cross-contract call) to ContractC.
+        // This is only possible because ContractA approved this contract (B) to spend its tokens.
+        token.transferFrom(msg.sender, contractC, amount);
+
+        emit TokensForwarded(tokenAddress, msg.sender, contractC, amount);
+    }
+}
+
+/**
+ * @title ContractC_TokenReceiver
+ * @notice The final destination for the tokens.
+ */
+contract ContractC_TokenReceiver {
+    // Function to check the token balance of this contract
+    function getTokenBalance(address tokenAddress) public view returns (uint256) {
+        return IERC20(tokenAddress).balanceOf(address(this));
+    }
+}
+
+/**
+ * @title ContractD_TokenRejector
+ * @notice This contract is designed to fail when asked to pull tokens.
+ */
+contract ContractD_TokenRejector {
+    function tryToPullTokens(address, address, uint256) external pure {
+        // This contract deliberately fails to complete its task.
+        // It could have faulty logic or, as in this case, simply revert.
+        revert("ContractD: I am programmed to reject this operation.");
+    }
+}


### PR DESCRIPTION
This pull request adds a new Solidity file, `Task_2.sol`, which demonstrates the standard `approve` and `transferFrom` pattern for executing multi-step ERC20 token transfers. The contracts illustrate both a successful forwarding chain (User -> A -> B -> C) and a transaction that is intentionally reverted by a downstream contract.

This provides a clear, practical example of how DeFi protocols can programmatically handle user tokens in a secure and standardized way.

#### Changes

* **`MyToken`**: A simple ERC20 contract with a `mint` function for testing.
* **`ContractA_TokenCaller`**: The entry point contract that pulls tokens from a user (after approval) and initiates the forwarding process.
* **`ContractB_TokenForwarder`**: A middleman contract that uses its allowance from Contract A to pull tokens and send them to the final destination.
* **`ContractC_TokenReceiver`**: The final destination for the tokens.
* **`ContractD_TokenRejector`**: A contract designed to always revert when its function is called, demonstrating how failures propagate up the call stack.

#### How to Test

1.  Deploy `MyToken`, `ContractA_TokenCaller`, `ContractB_TokenForwarder`, `ContractC_TokenReceiver`, and `ContractD_TokenRejector`.
2.  As a user (e.g., in Remix), call `mint()` on the `MyToken` contract to get some tokens (e.g., 1000).
3.  **User Approval**: Call `approve()` on the `MyToken` contract. Set the `spender` to the address of `ContractA_TokenCaller` and the `amount` to 100.

##### **Test Success Case (A -> B -> C)**

1.  Call `startForwardingChain()` on `ContractA_TokenCaller`.
2.  Provide the addresses for `MyToken`, `ContractB`, and `ContractC`, and set the `amount` to 100.
3.  **Expected Result**: The transaction should succeed. Check the balance of `ContractC_TokenReceiver` to confirm it has received 100 tokens.

##### **Test Rejection Case (A -> D)**

1.  Call `startRejectionChain()` on `ContractA_TokenCaller`.
2.  Provide the addresses for `MyToken` and `ContractD`, and set the `amount` to 100.
3.  **Expected Result**: The entire transaction should revert with the message "ContractD: I am programmed to reject this operation."

---
Please let me know for any required changes!